### PR TITLE
Add encoder and flow sensor payload metadata

### DIFF
--- a/Interface/Harp.OutputExpander/AsyncDevice.Generated.cs
+++ b/Interface/Harp.OutputExpander/AsyncDevice.Generated.cs
@@ -2040,29 +2040,29 @@ namespace Harp.OutputExpander
         }
 
         /// <summary>
-        /// Asynchronously reads the contents of the Encoder register.
+        /// Asynchronously reads the contents of the MagneticEncoder register.
         /// </summary>
         /// <returns>
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the register payload.
         /// </returns>
-        public async Task<ushort> ReadEncoderAsync()
+        public async Task<MagneticEncoderPayload> ReadMagneticEncoderAsync()
         {
-            var reply = await CommandAsync(HarpCommand.ReadUInt16(Encoder.Address));
-            return Encoder.GetPayload(reply);
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(MagneticEncoder.Address));
+            return MagneticEncoder.GetPayload(reply);
         }
 
         /// <summary>
-        /// Asynchronously reads the timestamped contents of the Encoder register.
+        /// Asynchronously reads the timestamped contents of the MagneticEncoder register.
         /// </summary>
         /// <returns>
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the timestamped register payload.
         /// </returns>
-        public async Task<Timestamped<ushort>> ReadTimestampedEncoderAsync()
+        public async Task<Timestamped<MagneticEncoderPayload>> ReadTimestampedMagneticEncoderAsync()
         {
-            var reply = await CommandAsync(HarpCommand.ReadUInt16(Encoder.Address));
-            return Encoder.GetTimestampedPayload(reply);
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(MagneticEncoder.Address));
+            return MagneticEncoder.GetTimestampedPayload(reply);
         }
 
         /// <summary>
@@ -2257,7 +2257,7 @@ namespace Harp.OutputExpander
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the register payload.
         /// </returns>
-        public async Task<short> ReadOpticalFlowAsync()
+        public async Task<OpticalFlowPayload> ReadOpticalFlowAsync()
         {
             var reply = await CommandAsync(HarpCommand.ReadInt16(OpticalFlow.Address));
             return OpticalFlow.GetPayload(reply);
@@ -2270,7 +2270,7 @@ namespace Harp.OutputExpander
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the timestamped register payload.
         /// </returns>
-        public async Task<Timestamped<short>> ReadTimestampedOpticalFlowAsync()
+        public async Task<Timestamped<OpticalFlowPayload>> ReadTimestampedOpticalFlowAsync()
         {
             var reply = await CommandAsync(HarpCommand.ReadInt16(OpticalFlow.Address));
             return OpticalFlow.GetTimestampedPayload(reply);

--- a/Interface/Harp.OutputExpander/AsyncDevice.Generated.cs
+++ b/Interface/Harp.OutputExpander/AsyncDevice.Generated.cs
@@ -2066,39 +2066,39 @@ namespace Harp.OutputExpander
         }
 
         /// <summary>
-        /// Asynchronously reads the contents of the EncoderSamplingRate register.
+        /// Asynchronously reads the contents of the MagneticEncoderSamplingRate register.
         /// </summary>
         /// <returns>
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the register payload.
         /// </returns>
-        public async Task<EncoderSamplingRateMode> ReadEncoderSamplingRateAsync()
+        public async Task<MagneticEncoderSamplingRateMode> ReadMagneticEncoderSamplingRateAsync()
         {
-            var reply = await CommandAsync(HarpCommand.ReadByte(EncoderSamplingRate.Address));
-            return EncoderSamplingRate.GetPayload(reply);
+            var reply = await CommandAsync(HarpCommand.ReadByte(MagneticEncoderSamplingRate.Address));
+            return MagneticEncoderSamplingRate.GetPayload(reply);
         }
 
         /// <summary>
-        /// Asynchronously reads the timestamped contents of the EncoderSamplingRate register.
+        /// Asynchronously reads the timestamped contents of the MagneticEncoderSamplingRate register.
         /// </summary>
         /// <returns>
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the timestamped register payload.
         /// </returns>
-        public async Task<Timestamped<EncoderSamplingRateMode>> ReadTimestampedEncoderSamplingRateAsync()
+        public async Task<Timestamped<MagneticEncoderSamplingRateMode>> ReadTimestampedMagneticEncoderSamplingRateAsync()
         {
-            var reply = await CommandAsync(HarpCommand.ReadByte(EncoderSamplingRate.Address));
-            return EncoderSamplingRate.GetTimestampedPayload(reply);
+            var reply = await CommandAsync(HarpCommand.ReadByte(MagneticEncoderSamplingRate.Address));
+            return MagneticEncoderSamplingRate.GetTimestampedPayload(reply);
         }
 
         /// <summary>
-        /// Asynchronously writes a value to the EncoderSamplingRate register.
+        /// Asynchronously writes a value to the MagneticEncoderSamplingRate register.
         /// </summary>
         /// <param name="value">The value to be stored in the register.</param>
         /// <returns>The task object representing the asynchronous write operation.</returns>
-        public async Task WriteEncoderSamplingRateAsync(EncoderSamplingRateMode value)
+        public async Task WriteMagneticEncoderSamplingRateAsync(MagneticEncoderSamplingRateMode value)
         {
-            var request = EncoderSamplingRate.FromPayload(MessageType.Write, value);
+            var request = MagneticEncoderSamplingRate.FromPayload(MessageType.Write, value);
             await CommandAsync(request);
         }
 

--- a/Interface/Harp.OutputExpander/AsyncDevice.Generated.cs
+++ b/Interface/Harp.OutputExpander/AsyncDevice.Generated.cs
@@ -2066,39 +2066,39 @@ namespace Harp.OutputExpander
         }
 
         /// <summary>
-        /// Asynchronously reads the contents of the MagneticEncoderSamplingRate register.
+        /// Asynchronously reads the contents of the MagneticEncoderSampleRate register.
         /// </summary>
         /// <returns>
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the register payload.
         /// </returns>
-        public async Task<MagneticEncoderSamplingRateMode> ReadMagneticEncoderSamplingRateAsync()
+        public async Task<MagneticEncoderSampleRateMode> ReadMagneticEncoderSampleRateAsync()
         {
-            var reply = await CommandAsync(HarpCommand.ReadByte(MagneticEncoderSamplingRate.Address));
-            return MagneticEncoderSamplingRate.GetPayload(reply);
+            var reply = await CommandAsync(HarpCommand.ReadByte(MagneticEncoderSampleRate.Address));
+            return MagneticEncoderSampleRate.GetPayload(reply);
         }
 
         /// <summary>
-        /// Asynchronously reads the timestamped contents of the MagneticEncoderSamplingRate register.
+        /// Asynchronously reads the timestamped contents of the MagneticEncoderSampleRate register.
         /// </summary>
         /// <returns>
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the timestamped register payload.
         /// </returns>
-        public async Task<Timestamped<MagneticEncoderSamplingRateMode>> ReadTimestampedMagneticEncoderSamplingRateAsync()
+        public async Task<Timestamped<MagneticEncoderSampleRateMode>> ReadTimestampedMagneticEncoderSampleRateAsync()
         {
-            var reply = await CommandAsync(HarpCommand.ReadByte(MagneticEncoderSamplingRate.Address));
-            return MagneticEncoderSamplingRate.GetTimestampedPayload(reply);
+            var reply = await CommandAsync(HarpCommand.ReadByte(MagneticEncoderSampleRate.Address));
+            return MagneticEncoderSampleRate.GetTimestampedPayload(reply);
         }
 
         /// <summary>
-        /// Asynchronously writes a value to the MagneticEncoderSamplingRate register.
+        /// Asynchronously writes a value to the MagneticEncoderSampleRate register.
         /// </summary>
         /// <param name="value">The value to be stored in the register.</param>
         /// <returns>The task object representing the asynchronous write operation.</returns>
-        public async Task WriteMagneticEncoderSamplingRateAsync(MagneticEncoderSamplingRateMode value)
+        public async Task WriteMagneticEncoderSampleRateAsync(MagneticEncoderSampleRateMode value)
         {
-            var request = MagneticEncoderSamplingRate.FromPayload(MessageType.Write, value);
+            var request = MagneticEncoderSampleRate.FromPayload(MessageType.Write, value);
             await CommandAsync(request);
         }
 

--- a/Interface/Harp.OutputExpander/Device.Generated.cs
+++ b/Interface/Harp.OutputExpander/Device.Generated.cs
@@ -94,7 +94,7 @@ namespace Harp.OutputExpander
             { 86, typeof(Out9PulseWidth) },
             { 87, typeof(ExpansionBoard) },
             { 90, typeof(MagneticEncoder) },
-            { 91, typeof(EncoderSamplingRate) },
+            { 91, typeof(MagneticEncoderSamplingRate) },
             { 94, typeof(ServoPeriod) },
             { 95, typeof(Servo0PulseWidth) },
             { 96, typeof(Servo1PulseWidth) },
@@ -185,7 +185,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="Out9PulseWidth"/>
     /// <seealso cref="ExpansionBoard"/>
     /// <seealso cref="MagneticEncoder"/>
-    /// <seealso cref="EncoderSamplingRate"/>
+    /// <seealso cref="MagneticEncoderSamplingRate"/>
     /// <seealso cref="ServoPeriod"/>
     /// <seealso cref="Servo0PulseWidth"/>
     /// <seealso cref="Servo1PulseWidth"/>
@@ -248,7 +248,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(Out9PulseWidth))]
     [XmlInclude(typeof(ExpansionBoard))]
     [XmlInclude(typeof(MagneticEncoder))]
-    [XmlInclude(typeof(EncoderSamplingRate))]
+    [XmlInclude(typeof(MagneticEncoderSamplingRate))]
     [XmlInclude(typeof(ServoPeriod))]
     [XmlInclude(typeof(Servo0PulseWidth))]
     [XmlInclude(typeof(Servo1PulseWidth))]
@@ -332,7 +332,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="Out9PulseWidth"/>
     /// <seealso cref="ExpansionBoard"/>
     /// <seealso cref="MagneticEncoder"/>
-    /// <seealso cref="EncoderSamplingRate"/>
+    /// <seealso cref="MagneticEncoderSamplingRate"/>
     /// <seealso cref="ServoPeriod"/>
     /// <seealso cref="Servo0PulseWidth"/>
     /// <seealso cref="Servo1PulseWidth"/>
@@ -395,7 +395,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(Out9PulseWidth))]
     [XmlInclude(typeof(ExpansionBoard))]
     [XmlInclude(typeof(MagneticEncoder))]
-    [XmlInclude(typeof(EncoderSamplingRate))]
+    [XmlInclude(typeof(MagneticEncoderSamplingRate))]
     [XmlInclude(typeof(ServoPeriod))]
     [XmlInclude(typeof(Servo0PulseWidth))]
     [XmlInclude(typeof(Servo1PulseWidth))]
@@ -458,7 +458,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(TimestampedOut9PulseWidth))]
     [XmlInclude(typeof(TimestampedExpansionBoard))]
     [XmlInclude(typeof(TimestampedMagneticEncoder))]
-    [XmlInclude(typeof(TimestampedEncoderSamplingRate))]
+    [XmlInclude(typeof(TimestampedMagneticEncoderSamplingRate))]
     [XmlInclude(typeof(TimestampedServoPeriod))]
     [XmlInclude(typeof(TimestampedServo0PulseWidth))]
     [XmlInclude(typeof(TimestampedServo1PulseWidth))]
@@ -539,7 +539,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="Out9PulseWidth"/>
     /// <seealso cref="ExpansionBoard"/>
     /// <seealso cref="MagneticEncoder"/>
-    /// <seealso cref="EncoderSamplingRate"/>
+    /// <seealso cref="MagneticEncoderSamplingRate"/>
     /// <seealso cref="ServoPeriod"/>
     /// <seealso cref="Servo0PulseWidth"/>
     /// <seealso cref="Servo1PulseWidth"/>
@@ -602,7 +602,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(Out9PulseWidth))]
     [XmlInclude(typeof(ExpansionBoard))]
     [XmlInclude(typeof(MagneticEncoder))]
-    [XmlInclude(typeof(EncoderSamplingRate))]
+    [XmlInclude(typeof(MagneticEncoderSamplingRate))]
     [XmlInclude(typeof(ServoPeriod))]
     [XmlInclude(typeof(Servo0PulseWidth))]
     [XmlInclude(typeof(Servo1PulseWidth))]
@@ -6144,70 +6144,70 @@ namespace Harp.OutputExpander
     /// Represents a register that sets the sampling rate of the magnetic encoder.
     /// </summary>
     [Description("Sets the sampling rate of the magnetic encoder.")]
-    public partial class EncoderSamplingRate
+    public partial class MagneticEncoderSamplingRate
     {
         /// <summary>
-        /// Represents the address of the <see cref="EncoderSamplingRate"/> register. This field is constant.
+        /// Represents the address of the <see cref="MagneticEncoderSamplingRate"/> register. This field is constant.
         /// </summary>
         public const int Address = 91;
 
         /// <summary>
-        /// Represents the payload type of the <see cref="EncoderSamplingRate"/> register. This field is constant.
+        /// Represents the payload type of the <see cref="MagneticEncoderSamplingRate"/> register. This field is constant.
         /// </summary>
         public const PayloadType RegisterType = PayloadType.U8;
 
         /// <summary>
-        /// Represents the length of the <see cref="EncoderSamplingRate"/> register. This field is constant.
+        /// Represents the length of the <see cref="MagneticEncoderSamplingRate"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
 
         /// <summary>
-        /// Returns the payload data for <see cref="EncoderSamplingRate"/> register messages.
+        /// Returns the payload data for <see cref="MagneticEncoderSamplingRate"/> register messages.
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the message payload.</returns>
-        public static EncoderSamplingRateMode GetPayload(HarpMessage message)
+        public static MagneticEncoderSamplingRateMode GetPayload(HarpMessage message)
         {
-            return (EncoderSamplingRateMode)message.GetPayloadByte();
+            return (MagneticEncoderSamplingRateMode)message.GetPayloadByte();
         }
 
         /// <summary>
-        /// Returns the timestamped payload data for <see cref="EncoderSamplingRate"/> register messages.
+        /// Returns the timestamped payload data for <see cref="MagneticEncoderSamplingRate"/> register messages.
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<EncoderSamplingRateMode> GetTimestampedPayload(HarpMessage message)
+        public static Timestamped<MagneticEncoderSamplingRateMode> GetTimestampedPayload(HarpMessage message)
         {
             var payload = message.GetTimestampedPayloadByte();
-            return Timestamped.Create((EncoderSamplingRateMode)payload.Value, payload.Seconds);
+            return Timestamped.Create((MagneticEncoderSamplingRateMode)payload.Value, payload.Seconds);
         }
 
         /// <summary>
-        /// Returns a Harp message for the <see cref="EncoderSamplingRate"/> register.
+        /// Returns a Harp message for the <see cref="MagneticEncoderSamplingRate"/> register.
         /// </summary>
         /// <param name="messageType">The type of the Harp message.</param>
         /// <param name="value">The value to be stored in the message payload.</param>
         /// <returns>
-        /// A <see cref="HarpMessage"/> object for the <see cref="EncoderSamplingRate"/> register
+        /// A <see cref="HarpMessage"/> object for the <see cref="MagneticEncoderSamplingRate"/> register
         /// with the specified message type and payload.
         /// </returns>
-        public static HarpMessage FromPayload(MessageType messageType, EncoderSamplingRateMode value)
+        public static HarpMessage FromPayload(MessageType messageType, MagneticEncoderSamplingRateMode value)
         {
             return HarpMessage.FromByte(Address, messageType, (byte)value);
         }
 
         /// <summary>
-        /// Returns a timestamped Harp message for the <see cref="EncoderSamplingRate"/>
+        /// Returns a timestamped Harp message for the <see cref="MagneticEncoderSamplingRate"/>
         /// register.
         /// </summary>
         /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
         /// <param name="messageType">The type of the Harp message.</param>
         /// <param name="value">The value to be stored in the message payload.</param>
         /// <returns>
-        /// A <see cref="HarpMessage"/> object for the <see cref="EncoderSamplingRate"/> register
+        /// A <see cref="HarpMessage"/> object for the <see cref="MagneticEncoderSamplingRate"/> register
         /// with the specified message type, timestamp, and payload.
         /// </returns>
-        public static HarpMessage FromPayload(double timestamp, MessageType messageType, EncoderSamplingRateMode value)
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, MagneticEncoderSamplingRateMode value)
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
@@ -6215,25 +6215,25 @@ namespace Harp.OutputExpander
 
     /// <summary>
     /// Provides methods for manipulating timestamped messages from the
-    /// EncoderSamplingRate register.
+    /// MagneticEncoderSamplingRate register.
     /// </summary>
-    /// <seealso cref="EncoderSamplingRate"/>
-    [Description("Filters and selects timestamped messages from the EncoderSamplingRate register.")]
-    public partial class TimestampedEncoderSamplingRate
+    /// <seealso cref="MagneticEncoderSamplingRate"/>
+    [Description("Filters and selects timestamped messages from the MagneticEncoderSamplingRate register.")]
+    public partial class TimestampedMagneticEncoderSamplingRate
     {
         /// <summary>
-        /// Represents the address of the <see cref="EncoderSamplingRate"/> register. This field is constant.
+        /// Represents the address of the <see cref="MagneticEncoderSamplingRate"/> register. This field is constant.
         /// </summary>
-        public const int Address = EncoderSamplingRate.Address;
+        public const int Address = MagneticEncoderSamplingRate.Address;
 
         /// <summary>
-        /// Returns timestamped payload data for <see cref="EncoderSamplingRate"/> register messages.
+        /// Returns timestamped payload data for <see cref="MagneticEncoderSamplingRate"/> register messages.
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<EncoderSamplingRateMode> GetPayload(HarpMessage message)
+        public static Timestamped<MagneticEncoderSamplingRateMode> GetPayload(HarpMessage message)
         {
-            return EncoderSamplingRate.GetTimestampedPayload(message);
+            return MagneticEncoderSamplingRate.GetTimestampedPayload(message);
         }
     }
 
@@ -6798,7 +6798,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="CreateOut9PulseWidthPayload"/>
     /// <seealso cref="CreateExpansionBoardPayload"/>
     /// <seealso cref="CreateMagneticEncoderPayload"/>
-    /// <seealso cref="CreateEncoderSamplingRatePayload"/>
+    /// <seealso cref="CreateMagneticEncoderSamplingRatePayload"/>
     /// <seealso cref="CreateServoPeriodPayload"/>
     /// <seealso cref="CreateServo0PulseWidthPayload"/>
     /// <seealso cref="CreateServo1PulseWidthPayload"/>
@@ -6861,7 +6861,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(CreateOut9PulseWidthPayload))]
     [XmlInclude(typeof(CreateExpansionBoardPayload))]
     [XmlInclude(typeof(CreateMagneticEncoderPayload))]
-    [XmlInclude(typeof(CreateEncoderSamplingRatePayload))]
+    [XmlInclude(typeof(CreateMagneticEncoderSamplingRatePayload))]
     [XmlInclude(typeof(CreateServoPeriodPayload))]
     [XmlInclude(typeof(CreateServo0PulseWidthPayload))]
     [XmlInclude(typeof(CreateServo1PulseWidthPayload))]
@@ -9645,16 +9645,16 @@ namespace Harp.OutputExpander
     /// Represents an operator that creates a sequence of message payloads
     /// that sets the sampling rate of the magnetic encoder.
     /// </summary>
-    [DisplayName("EncoderSamplingRatePayload")]
+    [DisplayName("MagneticEncoderSamplingRatePayload")]
     [WorkflowElementCategory(ElementCategory.Transform)]
     [Description("Creates a sequence of message payloads that sets the sampling rate of the magnetic encoder.")]
-    public partial class CreateEncoderSamplingRatePayload : HarpCombinator
+    public partial class CreateMagneticEncoderSamplingRatePayload : HarpCombinator
     {
         /// <summary>
         /// Gets or sets the value that sets the sampling rate of the magnetic encoder.
         /// </summary>
         [Description("The value that sets the sampling rate of the magnetic encoder.")]
-        public EncoderSamplingRateMode Value { get; set; }
+        public MagneticEncoderSamplingRateMode Value { get; set; }
 
         /// <summary>
         /// Creates an observable sequence that contains a single message
@@ -9685,7 +9685,7 @@ namespace Harp.OutputExpander
         /// </returns>
         public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
         {
-            return source.Select(_ => EncoderSamplingRate.FromPayload(MessageType, Value));
+            return source.Select(_ => MagneticEncoderSamplingRate.FromPayload(MessageType, Value));
         }
     }
 
@@ -10117,7 +10117,7 @@ namespace Harp.OutputExpander
     public enum ExpansionBoardType : byte
     {
         Breakout = 0,
-        Encoder = 1,
+        MagneticEncoder = 1,
         ServoMotor1 = 2,
         ServoMotor2 = 3,
         ServoMotor3 = 4,
@@ -10127,7 +10127,7 @@ namespace Harp.OutputExpander
     /// <summary>
     /// Specifies the sampling rate of the encoder.
     /// </summary>
-    public enum EncoderSamplingRateMode : byte
+    public enum MagneticEncoderSamplingRateMode : byte
     {
         SamplingRate50Hz = 0,
         SamplingRate100Hz = 1,

--- a/Interface/Harp.OutputExpander/Device.Generated.cs
+++ b/Interface/Harp.OutputExpander/Device.Generated.cs
@@ -93,7 +93,7 @@ namespace Harp.OutputExpander
             { 85, typeof(Out8PulseWidth) },
             { 86, typeof(Out9PulseWidth) },
             { 87, typeof(ExpansionBoard) },
-            { 90, typeof(Encoder) },
+            { 90, typeof(MagneticEncoder) },
             { 91, typeof(EncoderSamplingRate) },
             { 94, typeof(ServoPeriod) },
             { 95, typeof(Servo0PulseWidth) },
@@ -184,7 +184,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="Out8PulseWidth"/>
     /// <seealso cref="Out9PulseWidth"/>
     /// <seealso cref="ExpansionBoard"/>
-    /// <seealso cref="Encoder"/>
+    /// <seealso cref="MagneticEncoder"/>
     /// <seealso cref="EncoderSamplingRate"/>
     /// <seealso cref="ServoPeriod"/>
     /// <seealso cref="Servo0PulseWidth"/>
@@ -247,7 +247,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(Out8PulseWidth))]
     [XmlInclude(typeof(Out9PulseWidth))]
     [XmlInclude(typeof(ExpansionBoard))]
-    [XmlInclude(typeof(Encoder))]
+    [XmlInclude(typeof(MagneticEncoder))]
     [XmlInclude(typeof(EncoderSamplingRate))]
     [XmlInclude(typeof(ServoPeriod))]
     [XmlInclude(typeof(Servo0PulseWidth))]
@@ -331,7 +331,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="Out8PulseWidth"/>
     /// <seealso cref="Out9PulseWidth"/>
     /// <seealso cref="ExpansionBoard"/>
-    /// <seealso cref="Encoder"/>
+    /// <seealso cref="MagneticEncoder"/>
     /// <seealso cref="EncoderSamplingRate"/>
     /// <seealso cref="ServoPeriod"/>
     /// <seealso cref="Servo0PulseWidth"/>
@@ -394,7 +394,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(Out8PulseWidth))]
     [XmlInclude(typeof(Out9PulseWidth))]
     [XmlInclude(typeof(ExpansionBoard))]
-    [XmlInclude(typeof(Encoder))]
+    [XmlInclude(typeof(MagneticEncoder))]
     [XmlInclude(typeof(EncoderSamplingRate))]
     [XmlInclude(typeof(ServoPeriod))]
     [XmlInclude(typeof(Servo0PulseWidth))]
@@ -457,7 +457,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(TimestampedOut8PulseWidth))]
     [XmlInclude(typeof(TimestampedOut9PulseWidth))]
     [XmlInclude(typeof(TimestampedExpansionBoard))]
-    [XmlInclude(typeof(TimestampedEncoder))]
+    [XmlInclude(typeof(TimestampedMagneticEncoder))]
     [XmlInclude(typeof(TimestampedEncoderSamplingRate))]
     [XmlInclude(typeof(TimestampedServoPeriod))]
     [XmlInclude(typeof(TimestampedServo0PulseWidth))]
@@ -538,7 +538,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="Out8PulseWidth"/>
     /// <seealso cref="Out9PulseWidth"/>
     /// <seealso cref="ExpansionBoard"/>
-    /// <seealso cref="Encoder"/>
+    /// <seealso cref="MagneticEncoder"/>
     /// <seealso cref="EncoderSamplingRate"/>
     /// <seealso cref="ServoPeriod"/>
     /// <seealso cref="Servo0PulseWidth"/>
@@ -601,7 +601,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(Out8PulseWidth))]
     [XmlInclude(typeof(Out9PulseWidth))]
     [XmlInclude(typeof(ExpansionBoard))]
-    [XmlInclude(typeof(Encoder))]
+    [XmlInclude(typeof(MagneticEncoder))]
     [XmlInclude(typeof(EncoderSamplingRate))]
     [XmlInclude(typeof(ServoPeriod))]
     [XmlInclude(typeof(Servo0PulseWidth))]
@@ -6030,95 +6030,113 @@ namespace Harp.OutputExpander
     /// Represents a register that generated event with the latest read from the magnetic encoder.
     /// </summary>
     [Description("Generated event with the latest read from the magnetic encoder.")]
-    public partial class Encoder
+    public partial class MagneticEncoder
     {
         /// <summary>
-        /// Represents the address of the <see cref="Encoder"/> register. This field is constant.
+        /// Represents the address of the <see cref="MagneticEncoder"/> register. This field is constant.
         /// </summary>
         public const int Address = 90;
 
         /// <summary>
-        /// Represents the payload type of the <see cref="Encoder"/> register. This field is constant.
+        /// Represents the payload type of the <see cref="MagneticEncoder"/> register. This field is constant.
         /// </summary>
         public const PayloadType RegisterType = PayloadType.U16;
 
         /// <summary>
-        /// Represents the length of the <see cref="Encoder"/> register. This field is constant.
+        /// Represents the length of the <see cref="MagneticEncoder"/> register. This field is constant.
         /// </summary>
-        public const int RegisterLength = 1;
+        public const int RegisterLength = 2;
+
+        static MagneticEncoderPayload ParsePayload(ushort[] payload)
+        {
+            MagneticEncoderPayload result;
+            result.Angle = payload[0];
+            result.Magnitude = payload[1];
+            return result;
+        }
+
+        static ushort[] FormatPayload(MagneticEncoderPayload value)
+        {
+            ushort[] result;
+            result = new ushort[2];
+            result[0] = value.Angle;
+            result[1] = value.Magnitude;
+            return result;
+        }
 
         /// <summary>
-        /// Returns the payload data for <see cref="Encoder"/> register messages.
+        /// Returns the payload data for <see cref="MagneticEncoder"/> register messages.
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the message payload.</returns>
-        public static ushort GetPayload(HarpMessage message)
+        public static MagneticEncoderPayload GetPayload(HarpMessage message)
         {
-            return message.GetPayloadUInt16();
+            return ParsePayload(message.GetPayloadArray<ushort>());
         }
 
         /// <summary>
-        /// Returns the timestamped payload data for <see cref="Encoder"/> register messages.
+        /// Returns the timestamped payload data for <see cref="MagneticEncoder"/> register messages.
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        public static Timestamped<MagneticEncoderPayload> GetTimestampedPayload(HarpMessage message)
         {
-            return message.GetTimestampedPayloadUInt16();
+            var payload = message.GetTimestampedPayloadArray<ushort>();
+            return Timestamped.Create(ParsePayload(payload.Value), payload.Seconds);
         }
 
         /// <summary>
-        /// Returns a Harp message for the <see cref="Encoder"/> register.
+        /// Returns a Harp message for the <see cref="MagneticEncoder"/> register.
         /// </summary>
         /// <param name="messageType">The type of the Harp message.</param>
         /// <param name="value">The value to be stored in the message payload.</param>
         /// <returns>
-        /// A <see cref="HarpMessage"/> object for the <see cref="Encoder"/> register
+        /// A <see cref="HarpMessage"/> object for the <see cref="MagneticEncoder"/> register
         /// with the specified message type and payload.
         /// </returns>
-        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        public static HarpMessage FromPayload(MessageType messageType, MagneticEncoderPayload value)
         {
-            return HarpMessage.FromUInt16(Address, messageType, value);
+            return HarpMessage.FromUInt16(Address, messageType, FormatPayload(value));
         }
 
         /// <summary>
-        /// Returns a timestamped Harp message for the <see cref="Encoder"/>
+        /// Returns a timestamped Harp message for the <see cref="MagneticEncoder"/>
         /// register.
         /// </summary>
         /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
         /// <param name="messageType">The type of the Harp message.</param>
         /// <param name="value">The value to be stored in the message payload.</param>
         /// <returns>
-        /// A <see cref="HarpMessage"/> object for the <see cref="Encoder"/> register
+        /// A <see cref="HarpMessage"/> object for the <see cref="MagneticEncoder"/> register
         /// with the specified message type, timestamp, and payload.
         /// </returns>
-        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, MagneticEncoderPayload value)
         {
-            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, FormatPayload(value));
         }
     }
 
     /// <summary>
     /// Provides methods for manipulating timestamped messages from the
-    /// Encoder register.
+    /// MagneticEncoder register.
     /// </summary>
-    /// <seealso cref="Encoder"/>
-    [Description("Filters and selects timestamped messages from the Encoder register.")]
-    public partial class TimestampedEncoder
+    /// <seealso cref="MagneticEncoder"/>
+    [Description("Filters and selects timestamped messages from the MagneticEncoder register.")]
+    public partial class TimestampedMagneticEncoder
     {
         /// <summary>
-        /// Represents the address of the <see cref="Encoder"/> register. This field is constant.
+        /// Represents the address of the <see cref="MagneticEncoder"/> register. This field is constant.
         /// </summary>
-        public const int Address = Encoder.Address;
+        public const int Address = MagneticEncoder.Address;
 
         /// <summary>
-        /// Returns timestamped payload data for <see cref="Encoder"/> register messages.
+        /// Returns timestamped payload data for <see cref="MagneticEncoder"/> register messages.
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<ushort> GetPayload(HarpMessage message)
+        public static Timestamped<MagneticEncoderPayload> GetPayload(HarpMessage message)
         {
-            return Encoder.GetTimestampedPayload(message);
+            return MagneticEncoder.GetTimestampedPayload(message);
         }
     }
 
@@ -6622,16 +6640,35 @@ namespace Harp.OutputExpander
         /// <summary>
         /// Represents the length of the <see cref="OpticalFlow"/> register. This field is constant.
         /// </summary>
-        public const int RegisterLength = 1;
+        public const int RegisterLength = 3;
+
+        static OpticalFlowPayload ParsePayload(short[] payload)
+        {
+            OpticalFlowPayload result;
+            result.DeltaX = payload[0];
+            result.DeltaY = payload[1];
+            result.Squal = payload[2];
+            return result;
+        }
+
+        static short[] FormatPayload(OpticalFlowPayload value)
+        {
+            short[] result;
+            result = new short[3];
+            result[0] = value.DeltaX;
+            result[1] = value.DeltaY;
+            result[2] = value.Squal;
+            return result;
+        }
 
         /// <summary>
         /// Returns the payload data for <see cref="OpticalFlow"/> register messages.
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the message payload.</returns>
-        public static short GetPayload(HarpMessage message)
+        public static OpticalFlowPayload GetPayload(HarpMessage message)
         {
-            return message.GetPayloadInt16();
+            return ParsePayload(message.GetPayloadArray<short>());
         }
 
         /// <summary>
@@ -6639,9 +6676,10 @@ namespace Harp.OutputExpander
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<short> GetTimestampedPayload(HarpMessage message)
+        public static Timestamped<OpticalFlowPayload> GetTimestampedPayload(HarpMessage message)
         {
-            return message.GetTimestampedPayloadInt16();
+            var payload = message.GetTimestampedPayloadArray<short>();
+            return Timestamped.Create(ParsePayload(payload.Value), payload.Seconds);
         }
 
         /// <summary>
@@ -6653,9 +6691,9 @@ namespace Harp.OutputExpander
         /// A <see cref="HarpMessage"/> object for the <see cref="OpticalFlow"/> register
         /// with the specified message type and payload.
         /// </returns>
-        public static HarpMessage FromPayload(MessageType messageType, short value)
+        public static HarpMessage FromPayload(MessageType messageType, OpticalFlowPayload value)
         {
-            return HarpMessage.FromInt16(Address, messageType, value);
+            return HarpMessage.FromInt16(Address, messageType, FormatPayload(value));
         }
 
         /// <summary>
@@ -6669,9 +6707,9 @@ namespace Harp.OutputExpander
         /// A <see cref="HarpMessage"/> object for the <see cref="OpticalFlow"/> register
         /// with the specified message type, timestamp, and payload.
         /// </returns>
-        public static HarpMessage FromPayload(double timestamp, MessageType messageType, short value)
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, OpticalFlowPayload value)
         {
-            return HarpMessage.FromInt16(Address, timestamp, messageType, value);
+            return HarpMessage.FromInt16(Address, timestamp, messageType, FormatPayload(value));
         }
     }
 
@@ -6693,7 +6731,7 @@ namespace Harp.OutputExpander
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<short> GetPayload(HarpMessage message)
+        public static Timestamped<OpticalFlowPayload> GetPayload(HarpMessage message)
         {
             return OpticalFlow.GetTimestampedPayload(message);
         }
@@ -6759,7 +6797,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="CreateOut8PulseWidthPayload"/>
     /// <seealso cref="CreateOut9PulseWidthPayload"/>
     /// <seealso cref="CreateExpansionBoardPayload"/>
-    /// <seealso cref="CreateEncoderPayload"/>
+    /// <seealso cref="CreateMagneticEncoderPayload"/>
     /// <seealso cref="CreateEncoderSamplingRatePayload"/>
     /// <seealso cref="CreateServoPeriodPayload"/>
     /// <seealso cref="CreateServo0PulseWidthPayload"/>
@@ -6822,7 +6860,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(CreateOut8PulseWidthPayload))]
     [XmlInclude(typeof(CreateOut9PulseWidthPayload))]
     [XmlInclude(typeof(CreateExpansionBoardPayload))]
-    [XmlInclude(typeof(CreateEncoderPayload))]
+    [XmlInclude(typeof(CreateMagneticEncoderPayload))]
     [XmlInclude(typeof(CreateEncoderSamplingRatePayload))]
     [XmlInclude(typeof(CreateServoPeriodPayload))]
     [XmlInclude(typeof(CreateServo0PulseWidthPayload))]
@@ -9547,16 +9585,22 @@ namespace Harp.OutputExpander
     /// Represents an operator that creates a sequence of message payloads
     /// that generated event with the latest read from the magnetic encoder.
     /// </summary>
-    [DisplayName("EncoderPayload")]
+    [DisplayName("MagneticEncoderPayload")]
     [WorkflowElementCategory(ElementCategory.Transform)]
     [Description("Creates a sequence of message payloads that generated event with the latest read from the magnetic encoder.")]
-    public partial class CreateEncoderPayload : HarpCombinator
+    public partial class CreateMagneticEncoderPayload : HarpCombinator
     {
         /// <summary>
-        /// Gets or sets the value that generated event with the latest read from the magnetic encoder.
+        /// Gets or sets a value that the angle position measurement of the magnetic encoder.
         /// </summary>
-        [Description("The value that generated event with the latest read from the magnetic encoder.")]
-        public ushort Value { get; set; }
+        [Description("The angle position measurement of the magnetic encoder.")]
+        public ushort Angle { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the magnitude of the magnetic field.
+        /// </summary>
+        [Description("The magnitude of the magnetic field.")]
+        public ushort Magnitude { get; set; }
 
         /// <summary>
         /// Creates an observable sequence that contains a single message
@@ -9587,7 +9631,13 @@ namespace Harp.OutputExpander
         /// </returns>
         public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
         {
-            return source.Select(_ => Encoder.FromPayload(MessageType, Value));
+            return source.Select(_ =>
+            {
+                MagneticEncoderPayload value;
+                value.Angle = Angle;
+                value.Magnitude = Magnitude;
+                return MagneticEncoder.FromPayload(MessageType, value);
+            });
         }
     }
 
@@ -9841,10 +9891,22 @@ namespace Harp.OutputExpander
     public partial class CreateOpticalFlowPayload : HarpCombinator
     {
         /// <summary>
-        /// Gets or sets the value that generated event with the latest read from the optical flow sensor.
+        /// Gets or sets a value that the movement in the X axis.
         /// </summary>
-        [Description("The value that generated event with the latest read from the optical flow sensor.")]
-        public short Value { get; set; }
+        [Description("The movement in the X axis.")]
+        public short DeltaX { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the movement in the Y axis.
+        /// </summary>
+        [Description("The movement in the Y axis.")]
+        public short DeltaY { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that the measure of the number of features visible by the sensor.
+        /// </summary>
+        [Description("The measure of the number of features visible by the sensor.")]
+        public short Squal { get; set; }
 
         /// <summary>
         /// Creates an observable sequence that contains a single message
@@ -9875,8 +9937,81 @@ namespace Harp.OutputExpander
         /// </returns>
         public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
         {
-            return source.Select(_ => OpticalFlow.FromPayload(MessageType, Value));
+            return source.Select(_ =>
+            {
+                OpticalFlowPayload value;
+                value.DeltaX = DeltaX;
+                value.DeltaY = DeltaY;
+                value.Squal = Squal;
+                return OpticalFlow.FromPayload(MessageType, value);
+            });
         }
+    }
+
+    /// <summary>
+    /// Represents the payload of the MagneticEncoder register.
+    /// </summary>
+    public struct MagneticEncoderPayload
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MagneticEncoderPayload"/> structure.
+        /// </summary>
+        /// <param name="angle">The angle position measurement of the magnetic encoder.</param>
+        /// <param name="magnitude">The magnitude of the magnetic field.</param>
+        public MagneticEncoderPayload(
+            ushort angle,
+            ushort magnitude)
+        {
+            Angle = angle;
+            Magnitude = magnitude;
+        }
+
+        /// <summary>
+        /// The angle position measurement of the magnetic encoder.
+        /// </summary>
+        public ushort Angle;
+
+        /// <summary>
+        /// The magnitude of the magnetic field.
+        /// </summary>
+        public ushort Magnitude;
+    }
+
+    /// <summary>
+    /// Represents the payload of the OpticalFlow register.
+    /// </summary>
+    public struct OpticalFlowPayload
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpticalFlowPayload"/> structure.
+        /// </summary>
+        /// <param name="deltaX">The movement in the X axis.</param>
+        /// <param name="deltaY">The movement in the Y axis.</param>
+        /// <param name="squal">The measure of the number of features visible by the sensor.</param>
+        public OpticalFlowPayload(
+            short deltaX,
+            short deltaY,
+            short squal)
+        {
+            DeltaX = deltaX;
+            DeltaY = deltaY;
+            Squal = squal;
+        }
+
+        /// <summary>
+        /// The movement in the X axis.
+        /// </summary>
+        public short DeltaX;
+
+        /// <summary>
+        /// The movement in the Y axis.
+        /// </summary>
+        public short DeltaY;
+
+        /// <summary>
+        /// The measure of the number of features visible by the sensor.
+        /// </summary>
+        public short Squal;
     }
 
     /// <summary>

--- a/Interface/Harp.OutputExpander/Device.Generated.cs
+++ b/Interface/Harp.OutputExpander/Device.Generated.cs
@@ -94,7 +94,7 @@ namespace Harp.OutputExpander
             { 86, typeof(Out9PulseWidth) },
             { 87, typeof(ExpansionBoard) },
             { 90, typeof(MagneticEncoder) },
-            { 91, typeof(MagneticEncoderSamplingRate) },
+            { 91, typeof(MagneticEncoderSampleRate) },
             { 94, typeof(ServoPeriod) },
             { 95, typeof(Servo0PulseWidth) },
             { 96, typeof(Servo1PulseWidth) },
@@ -185,7 +185,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="Out9PulseWidth"/>
     /// <seealso cref="ExpansionBoard"/>
     /// <seealso cref="MagneticEncoder"/>
-    /// <seealso cref="MagneticEncoderSamplingRate"/>
+    /// <seealso cref="MagneticEncoderSampleRate"/>
     /// <seealso cref="ServoPeriod"/>
     /// <seealso cref="Servo0PulseWidth"/>
     /// <seealso cref="Servo1PulseWidth"/>
@@ -248,7 +248,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(Out9PulseWidth))]
     [XmlInclude(typeof(ExpansionBoard))]
     [XmlInclude(typeof(MagneticEncoder))]
-    [XmlInclude(typeof(MagneticEncoderSamplingRate))]
+    [XmlInclude(typeof(MagneticEncoderSampleRate))]
     [XmlInclude(typeof(ServoPeriod))]
     [XmlInclude(typeof(Servo0PulseWidth))]
     [XmlInclude(typeof(Servo1PulseWidth))]
@@ -332,7 +332,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="Out9PulseWidth"/>
     /// <seealso cref="ExpansionBoard"/>
     /// <seealso cref="MagneticEncoder"/>
-    /// <seealso cref="MagneticEncoderSamplingRate"/>
+    /// <seealso cref="MagneticEncoderSampleRate"/>
     /// <seealso cref="ServoPeriod"/>
     /// <seealso cref="Servo0PulseWidth"/>
     /// <seealso cref="Servo1PulseWidth"/>
@@ -395,7 +395,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(Out9PulseWidth))]
     [XmlInclude(typeof(ExpansionBoard))]
     [XmlInclude(typeof(MagneticEncoder))]
-    [XmlInclude(typeof(MagneticEncoderSamplingRate))]
+    [XmlInclude(typeof(MagneticEncoderSampleRate))]
     [XmlInclude(typeof(ServoPeriod))]
     [XmlInclude(typeof(Servo0PulseWidth))]
     [XmlInclude(typeof(Servo1PulseWidth))]
@@ -458,7 +458,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(TimestampedOut9PulseWidth))]
     [XmlInclude(typeof(TimestampedExpansionBoard))]
     [XmlInclude(typeof(TimestampedMagneticEncoder))]
-    [XmlInclude(typeof(TimestampedMagneticEncoderSamplingRate))]
+    [XmlInclude(typeof(TimestampedMagneticEncoderSampleRate))]
     [XmlInclude(typeof(TimestampedServoPeriod))]
     [XmlInclude(typeof(TimestampedServo0PulseWidth))]
     [XmlInclude(typeof(TimestampedServo1PulseWidth))]
@@ -539,7 +539,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="Out9PulseWidth"/>
     /// <seealso cref="ExpansionBoard"/>
     /// <seealso cref="MagneticEncoder"/>
-    /// <seealso cref="MagneticEncoderSamplingRate"/>
+    /// <seealso cref="MagneticEncoderSampleRate"/>
     /// <seealso cref="ServoPeriod"/>
     /// <seealso cref="Servo0PulseWidth"/>
     /// <seealso cref="Servo1PulseWidth"/>
@@ -602,7 +602,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(Out9PulseWidth))]
     [XmlInclude(typeof(ExpansionBoard))]
     [XmlInclude(typeof(MagneticEncoder))]
-    [XmlInclude(typeof(MagneticEncoderSamplingRate))]
+    [XmlInclude(typeof(MagneticEncoderSampleRate))]
     [XmlInclude(typeof(ServoPeriod))]
     [XmlInclude(typeof(Servo0PulseWidth))]
     [XmlInclude(typeof(Servo1PulseWidth))]
@@ -6141,73 +6141,73 @@ namespace Harp.OutputExpander
     }
 
     /// <summary>
-    /// Represents a register that sets the sampling rate of the magnetic encoder.
+    /// Represents a register that sets the sample rate of the magnetic encoder.
     /// </summary>
-    [Description("Sets the sampling rate of the magnetic encoder.")]
-    public partial class MagneticEncoderSamplingRate
+    [Description("Sets the sample rate of the magnetic encoder.")]
+    public partial class MagneticEncoderSampleRate
     {
         /// <summary>
-        /// Represents the address of the <see cref="MagneticEncoderSamplingRate"/> register. This field is constant.
+        /// Represents the address of the <see cref="MagneticEncoderSampleRate"/> register. This field is constant.
         /// </summary>
         public const int Address = 91;
 
         /// <summary>
-        /// Represents the payload type of the <see cref="MagneticEncoderSamplingRate"/> register. This field is constant.
+        /// Represents the payload type of the <see cref="MagneticEncoderSampleRate"/> register. This field is constant.
         /// </summary>
         public const PayloadType RegisterType = PayloadType.U8;
 
         /// <summary>
-        /// Represents the length of the <see cref="MagneticEncoderSamplingRate"/> register. This field is constant.
+        /// Represents the length of the <see cref="MagneticEncoderSampleRate"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
 
         /// <summary>
-        /// Returns the payload data for <see cref="MagneticEncoderSamplingRate"/> register messages.
+        /// Returns the payload data for <see cref="MagneticEncoderSampleRate"/> register messages.
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the message payload.</returns>
-        public static MagneticEncoderSamplingRateMode GetPayload(HarpMessage message)
+        public static MagneticEncoderSampleRateMode GetPayload(HarpMessage message)
         {
-            return (MagneticEncoderSamplingRateMode)message.GetPayloadByte();
+            return (MagneticEncoderSampleRateMode)message.GetPayloadByte();
         }
 
         /// <summary>
-        /// Returns the timestamped payload data for <see cref="MagneticEncoderSamplingRate"/> register messages.
+        /// Returns the timestamped payload data for <see cref="MagneticEncoderSampleRate"/> register messages.
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<MagneticEncoderSamplingRateMode> GetTimestampedPayload(HarpMessage message)
+        public static Timestamped<MagneticEncoderSampleRateMode> GetTimestampedPayload(HarpMessage message)
         {
             var payload = message.GetTimestampedPayloadByte();
-            return Timestamped.Create((MagneticEncoderSamplingRateMode)payload.Value, payload.Seconds);
+            return Timestamped.Create((MagneticEncoderSampleRateMode)payload.Value, payload.Seconds);
         }
 
         /// <summary>
-        /// Returns a Harp message for the <see cref="MagneticEncoderSamplingRate"/> register.
+        /// Returns a Harp message for the <see cref="MagneticEncoderSampleRate"/> register.
         /// </summary>
         /// <param name="messageType">The type of the Harp message.</param>
         /// <param name="value">The value to be stored in the message payload.</param>
         /// <returns>
-        /// A <see cref="HarpMessage"/> object for the <see cref="MagneticEncoderSamplingRate"/> register
+        /// A <see cref="HarpMessage"/> object for the <see cref="MagneticEncoderSampleRate"/> register
         /// with the specified message type and payload.
         /// </returns>
-        public static HarpMessage FromPayload(MessageType messageType, MagneticEncoderSamplingRateMode value)
+        public static HarpMessage FromPayload(MessageType messageType, MagneticEncoderSampleRateMode value)
         {
             return HarpMessage.FromByte(Address, messageType, (byte)value);
         }
 
         /// <summary>
-        /// Returns a timestamped Harp message for the <see cref="MagneticEncoderSamplingRate"/>
+        /// Returns a timestamped Harp message for the <see cref="MagneticEncoderSampleRate"/>
         /// register.
         /// </summary>
         /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
         /// <param name="messageType">The type of the Harp message.</param>
         /// <param name="value">The value to be stored in the message payload.</param>
         /// <returns>
-        /// A <see cref="HarpMessage"/> object for the <see cref="MagneticEncoderSamplingRate"/> register
+        /// A <see cref="HarpMessage"/> object for the <see cref="MagneticEncoderSampleRate"/> register
         /// with the specified message type, timestamp, and payload.
         /// </returns>
-        public static HarpMessage FromPayload(double timestamp, MessageType messageType, MagneticEncoderSamplingRateMode value)
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, MagneticEncoderSampleRateMode value)
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
@@ -6215,25 +6215,25 @@ namespace Harp.OutputExpander
 
     /// <summary>
     /// Provides methods for manipulating timestamped messages from the
-    /// MagneticEncoderSamplingRate register.
+    /// MagneticEncoderSampleRate register.
     /// </summary>
-    /// <seealso cref="MagneticEncoderSamplingRate"/>
-    [Description("Filters and selects timestamped messages from the MagneticEncoderSamplingRate register.")]
-    public partial class TimestampedMagneticEncoderSamplingRate
+    /// <seealso cref="MagneticEncoderSampleRate"/>
+    [Description("Filters and selects timestamped messages from the MagneticEncoderSampleRate register.")]
+    public partial class TimestampedMagneticEncoderSampleRate
     {
         /// <summary>
-        /// Represents the address of the <see cref="MagneticEncoderSamplingRate"/> register. This field is constant.
+        /// Represents the address of the <see cref="MagneticEncoderSampleRate"/> register. This field is constant.
         /// </summary>
-        public const int Address = MagneticEncoderSamplingRate.Address;
+        public const int Address = MagneticEncoderSampleRate.Address;
 
         /// <summary>
-        /// Returns timestamped payload data for <see cref="MagneticEncoderSamplingRate"/> register messages.
+        /// Returns timestamped payload data for <see cref="MagneticEncoderSampleRate"/> register messages.
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<MagneticEncoderSamplingRateMode> GetPayload(HarpMessage message)
+        public static Timestamped<MagneticEncoderSampleRateMode> GetPayload(HarpMessage message)
         {
-            return MagneticEncoderSamplingRate.GetTimestampedPayload(message);
+            return MagneticEncoderSampleRate.GetTimestampedPayload(message);
         }
     }
 
@@ -6798,7 +6798,7 @@ namespace Harp.OutputExpander
     /// <seealso cref="CreateOut9PulseWidthPayload"/>
     /// <seealso cref="CreateExpansionBoardPayload"/>
     /// <seealso cref="CreateMagneticEncoderPayload"/>
-    /// <seealso cref="CreateMagneticEncoderSamplingRatePayload"/>
+    /// <seealso cref="CreateMagneticEncoderSampleRatePayload"/>
     /// <seealso cref="CreateServoPeriodPayload"/>
     /// <seealso cref="CreateServo0PulseWidthPayload"/>
     /// <seealso cref="CreateServo1PulseWidthPayload"/>
@@ -6861,7 +6861,7 @@ namespace Harp.OutputExpander
     [XmlInclude(typeof(CreateOut9PulseWidthPayload))]
     [XmlInclude(typeof(CreateExpansionBoardPayload))]
     [XmlInclude(typeof(CreateMagneticEncoderPayload))]
-    [XmlInclude(typeof(CreateMagneticEncoderSamplingRatePayload))]
+    [XmlInclude(typeof(CreateMagneticEncoderSampleRatePayload))]
     [XmlInclude(typeof(CreateServoPeriodPayload))]
     [XmlInclude(typeof(CreateServo0PulseWidthPayload))]
     [XmlInclude(typeof(CreateServo1PulseWidthPayload))]
@@ -9643,22 +9643,22 @@ namespace Harp.OutputExpander
 
     /// <summary>
     /// Represents an operator that creates a sequence of message payloads
-    /// that sets the sampling rate of the magnetic encoder.
+    /// that sets the sample rate of the magnetic encoder.
     /// </summary>
-    [DisplayName("MagneticEncoderSamplingRatePayload")]
+    [DisplayName("MagneticEncoderSampleRatePayload")]
     [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that sets the sampling rate of the magnetic encoder.")]
-    public partial class CreateMagneticEncoderSamplingRatePayload : HarpCombinator
+    [Description("Creates a sequence of message payloads that sets the sample rate of the magnetic encoder.")]
+    public partial class CreateMagneticEncoderSampleRatePayload : HarpCombinator
     {
         /// <summary>
-        /// Gets or sets the value that sets the sampling rate of the magnetic encoder.
+        /// Gets or sets the value that sets the sample rate of the magnetic encoder.
         /// </summary>
-        [Description("The value that sets the sampling rate of the magnetic encoder.")]
-        public MagneticEncoderSamplingRateMode Value { get; set; }
+        [Description("The value that sets the sample rate of the magnetic encoder.")]
+        public MagneticEncoderSampleRateMode Value { get; set; }
 
         /// <summary>
         /// Creates an observable sequence that contains a single message
-        /// that sets the sampling rate of the magnetic encoder.
+        /// that sets the sample rate of the magnetic encoder.
         /// </summary>
         /// <returns>
         /// A sequence containing a single <see cref="HarpMessage"/> object
@@ -9671,7 +9671,7 @@ namespace Harp.OutputExpander
 
         /// <summary>
         /// Creates an observable sequence of message payloads
-        /// that sets the sampling rate of the magnetic encoder.
+        /// that sets the sample rate of the magnetic encoder.
         /// </summary>
         /// <typeparam name="TSource">
         /// The type of the elements in the <paramref name="source"/> sequence.
@@ -9685,7 +9685,7 @@ namespace Harp.OutputExpander
         /// </returns>
         public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
         {
-            return source.Select(_ => MagneticEncoderSamplingRate.FromPayload(MessageType, Value));
+            return source.Select(_ => MagneticEncoderSampleRate.FromPayload(MessageType, Value));
         }
     }
 
@@ -10125,15 +10125,15 @@ namespace Harp.OutputExpander
     }
 
     /// <summary>
-    /// Specifies the sampling rate of the encoder.
+    /// Specifies the sample rate of the encoder.
     /// </summary>
-    public enum MagneticEncoderSamplingRateMode : byte
+    public enum MagneticEncoderSampleRateMode : byte
     {
-        SamplingRate50Hz = 0,
-        SamplingRate100Hz = 1,
-        SamplingRate200Hz = 2,
-        SamplingRate250Hz = 3,
-        SamplingRate500Hz = 4,
-        SamplingRate1000Hz = 5
+        SampleRate50Hz = 0,
+        SampleRate100Hz = 1,
+        SampleRate200Hz = 2,
+        SampleRate250Hz = 3,
+        SampleRate500Hz = 4,
+        SampleRate1000Hz = 5
     }
 }

--- a/Interface/Harp.OutputExpander/Harp.OutputExpander.csproj
+++ b/Interface/Harp.OutputExpander/Harp.OutputExpander.csproj
@@ -17,7 +17,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>icon.png</PackageIcon>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>0.1.0-preview2</VersionPrefix>
+    <VersionPrefix>0.1.0-preview3</VersionPrefix>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/Interface/Harp.OutputExpander/Harp.OutputExpander.csproj
+++ b/Interface/Harp.OutputExpander/Harp.OutputExpander.csproj
@@ -17,7 +17,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>icon.png</PackageIcon>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>0.1.0-preview3</VersionPrefix>
+    <VersionPrefix>0.1.0-preview4</VersionPrefix>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/device.yml
+++ b/device.yml
@@ -289,11 +289,11 @@ registers:
       Magnitude:
         offset: 1
         description: The magnitude of the magnetic field.
-  EncoderSamplingRate:
+  MagneticEncoderSamplingRate:
     address: 91
     type: U8
     access: Write
-    maskType: EncoderSamplingRateMode
+    maskType: MagneticEncoderSamplingRateMode
     description: Sets the sampling rate of the magnetic encoder.
   Reserved2:
     <<: *reserved
@@ -406,12 +406,12 @@ groupMasks:
     description: Specifies the available expansion boards implemented.
     values:
       Breakout: 0
-      Encoder: 1
+      MagneticEncoder: 1
       ServoMotor1: 2
       ServoMotor2: 3
       ServoMotor3: 4
       OpticalFlow: 5
-  EncoderSamplingRateMode:
+  MagneticEncoderSamplingRateMode:
     description: Specifies the sampling rate of the encoder.
     values:
       SamplingRate50Hz: 0

--- a/device.yml
+++ b/device.yml
@@ -289,12 +289,12 @@ registers:
       Magnitude:
         offset: 1
         description: The magnitude of the magnetic field.
-  MagneticEncoderSamplingRate:
+  MagneticEncoderSampleRate:
     address: 91
     type: U8
     access: Write
-    maskType: MagneticEncoderSamplingRateMode
-    description: Sets the sampling rate of the magnetic encoder.
+    maskType: MagneticEncoderSampleRateMode
+    description: Sets the sample rate of the magnetic encoder.
   Reserved2:
     <<: *reserved
     address: 92
@@ -411,12 +411,12 @@ groupMasks:
       ServoMotor2: 3
       ServoMotor3: 4
       OpticalFlow: 5
-  MagneticEncoderSamplingRateMode:
-    description: Specifies the sampling rate of the encoder.
+  MagneticEncoderSampleRateMode:
+    description: Specifies the sample rate of the encoder.
     values:
-      SamplingRate50Hz: 0
-      SamplingRate100Hz: 1
-      SamplingRate200Hz: 2
-      SamplingRate250Hz: 3
-      SamplingRate500Hz: 4
-      SamplingRate1000Hz: 5
+      SampleRate50Hz: 0
+      SampleRate100Hz: 1
+      SampleRate200Hz: 2
+      SampleRate250Hz: 3
+      SampleRate500Hz: 4
+      SampleRate1000Hz: 5

--- a/device.yml
+++ b/device.yml
@@ -276,11 +276,19 @@ registers:
   Reserved1:
     <<: *reserved
     address: 89
-  Encoder:
+  MagneticEncoder:
     address: 90
     type: U16
+    length: 2
     access: Event
     description: Generated event with the latest read from the magnetic encoder.
+    payloadSpec:
+      Angle:
+        offset: 0
+        description: The angle position measurement of the magnetic encoder.
+      Magnitude:
+        offset: 1
+        description: The magnitude of the magnetic field.
   EncoderSamplingRate:
     address: 91
     type: U8
@@ -320,8 +328,19 @@ registers:
   OpticalFlow:
     address: 100
     type: S16
+    length: 3
     access: Event
     description: Generated event with the latest read from the optical flow sensor.
+    payloadSpec:
+      DeltaX:
+        offset: 0
+        description: The movement in the X axis.
+      DeltaY:
+        offset: 1
+        description: The movement in the Y axis.
+      Squal:
+        offset: 2
+        description: The measure of the number of features visible by the sensor.
 bitMasks:
   AuxiliaryInputs:
     bits:


### PR DESCRIPTION
This PR adds missing metadata for the magnetic encoder and flow sensor payloads:
  - MagneticEncoder
    - Angle
    - Magnitude
  - OpticalFlow
    - DeltaX
    - DeltaY
    - Squal