### PR TITLE
Add high-level operators for complex register configuration

### DIFF
--- a/Interface/Harp.OutputExpander/ConfigureMagneticEncoder.cs
+++ b/Interface/Harp.OutputExpander/ConfigureMagneticEncoder.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai.Harp;
+using Bonsai;
+
+namespace Harp.OutputExpander
+{
+    /// <summary>
+    /// Represents an operator that generates a sequence of Harp messages to
+    /// configure the magnetic encoder expansion.
+    /// </summary>
+    [Description("Generates a sequence of Harp messages to configure the magnetic encoder in OutputExpander devices.")]
+    public class ConfigureMagneticEncoder : Source<HarpMessage>
+    {
+        /// <summary>
+        /// Gets or sets a value specifying the sampling rate of the magnetic encoder.
+        /// </summary>
+        [Description("Specifies the sampling rate of the magnetic encoder.")]
+        public MagneticEncoderSampleRateMode SampleRate { get; set; } = MagneticEncoderSampleRateMode.SampleRate1000Hz;
+
+        IEnumerable<HarpMessage> CreateMessageSequence()
+        {
+            yield return ExpansionBoard.FromPayload(MessageType.Write, ExpansionBoardType.MagneticEncoder);
+            yield return MagneticEncoderSampleRate.FromPayload(MessageType.Write, SampleRate);
+        }
+
+        /// <summary>
+        /// Generates an observable sequence of Harp messages to configure the
+        /// magnetic encoder expansion.
+        /// </summary>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing the commands
+        /// needed to fully configure the magnetic encoder expansion.
+        /// </returns>
+        public override IObservable<HarpMessage> Generate()
+        {
+            return CreateMessageSequence().ToObservable();
+        }
+
+        /// <summary>
+        /// Generates an observable sequence of Harp messages to configure the
+        /// magnetic encoder expansion whenever the source sequence emits a notification.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used to emit new configuration
+        /// messages.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing the commands
+        /// needed to fully configure the magnetic encoder expansion.
+        /// </returns>
+        public IObservable<HarpMessage> Generate<TSource>(IObservable<TSource> source)
+        {
+            return source.SelectMany(input => CreateMessageSequence());
+        }
+    }
+}

--- a/Interface/Harp.OutputExpander/ConfigurePwm.cs
+++ b/Interface/Harp.OutputExpander/ConfigurePwm.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai.Harp;
+using Bonsai;
+
+namespace Harp.OutputExpander
+{
+    /// <summary>
+    /// Represents an operator that generates a sequence of Harp messages to
+    /// configure the PWM feature.
+    /// </summary>
+    [Description("Generates a sequence of Harp messages to configure the PWM feature.")]
+    public class ConfigurePwm : Source<HarpMessage>
+    {
+        /// <summary>
+        /// Gets or sets a value specifying which PWM digital outputs to configure.
+        /// </summary>
+        [Description("Specifies which PWM digital outputs to enable.")]
+        public PwmOutputs Mask { get; set; } = PwmOutputs.PwmOutput1;
+
+        /// <summary>
+        /// Gets or sets the frequency of the PWM. The maximum frequency is 1000Hz.
+        /// </summary>
+        [Description("The frequency of the PWM. The maximum frequency is 1000Hz.")]
+        public float Frequency { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duty cycle of the PWM. The maximum value is 100%.
+        /// </summary>
+        [Description("The duty cycle of the PWM. The maximum value is 100%.")]
+        public float DutyCycle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of pulses to trigger on the specified PWM.
+        /// If the default value of zero is specified, the PWM will be infinite.
+        /// </summary>
+        [Description("The number of pulses to trigger on the specified PWM. If the default value of zero is specified, the PWM will be infinite.")]
+        public int PulseCount { get; set; }
+
+        IEnumerable<HarpMessage> CreateMessageSequence()
+        {
+            byte pwmOffset;
+            var mask = Mask;
+            if (mask >= PwmOutputs.PwmOutput9) pwmOffset = Pwm2Frequency.Address;
+            else if (mask >= PwmOutputs.PwmOutput6) pwmOffset = Pwm1Frequency.Address;
+            else pwmOffset = Pwm0Frequency.Address;
+            yield return PwmAndStimEnable.FromPayload(MessageType.Write, (PwmAndStimMappings)Mask);
+            yield return HarpCommand.WriteSingle(pwmOffset + PwmFrequency, Frequency);
+            yield return HarpCommand.WriteSingle(pwmOffset + PwmDutyCycle, DutyCycle);
+            if (PulseCount > 0)
+            {
+                yield return HarpCommand.WriteUInt16(pwmOffset + PwmPulseCount, (ushort)PulseCount);
+                yield return HarpCommand.WriteByte(pwmOffset + PwmAcquisitionMode, (byte)AcquisitionMode.Finite);
+            }
+            else yield return HarpCommand.WriteByte(pwmOffset + PwmAcquisitionMode, (byte)AcquisitionMode.Continuous);
+            yield return HarpCommand.WriteByte(pwmOffset + PwmTriggerSource, (byte)TriggerSource.Software);
+            yield return HarpCommand.WriteByte(pwmOffset + PwmEventConfig, (byte)EnableFlag.Enabled);
+        }
+
+        /// <summary>
+        /// Generates an observable sequence of Harp messages to configure the
+        /// PWM feature.
+        /// </summary>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing the commands
+        /// needed to fully configure the PWM feature.
+        /// </returns>
+        public override IObservable<HarpMessage> Generate()
+        {
+            return CreateMessageSequence().ToObservable();
+        }
+
+        /// <summary>
+        /// Generates an observable sequence of Harp messages to configure the
+        /// PWM feature whenever the source sequence emits a notification.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used to emit new configuration
+        /// messages.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing the commands
+        /// needed to fully configure the PWM feature.
+        /// </returns>
+        public IObservable<HarpMessage> Generate<TSource>(IObservable<TSource> source)
+        {
+            return source.SelectMany(input => CreateMessageSequence());
+        }
+
+        const int PwmFrequency = Pwm0Frequency.Address - Pwm0Frequency.Address;
+        const int PwmDutyCycle = Pwm0DutyCycle.Address - Pwm0Frequency.Address;
+        const int PwmPulseCount = Pwm0PulseCount.Address - Pwm0Frequency.Address;
+        const int PwmAcquisitionMode = Pwm0AcquisitionMode.Address - Pwm0Frequency.Address;
+        const int PwmTriggerSource = Pwm0TriggerSource.Address - Pwm0Frequency.Address;
+        const int PwmEventConfig = Pwm0EventConfig.Address - Pwm0Frequency.Address;
+    }
+
+    /// <summary>
+    /// Specifies the digital output lines available for PWM.
+    /// </summary>
+    [Flags]
+    public enum PwmOutputs : ushort
+    {
+        None = PwmAndStimMappings.None,
+        PwmOutput1 = PwmAndStimMappings.Pwm0ToOut1,
+        PwmOutput2 = PwmAndStimMappings.Pwm0ToOut2,
+        PwmOutput3 = PwmAndStimMappings.Pwm0ToOut3,
+        PwmOutput6 = PwmAndStimMappings.Pwm1ToOut6,
+        PwmOutput7 = PwmAndStimMappings.Pwm1ToOut7,
+        PwmOutput8 = PwmAndStimMappings.Pwm1ToOut8,
+        PwmOutput9 = PwmAndStimMappings.Pwm2ToOut9
+    }
+}

--- a/Interface/Harp.OutputExpander/Harp.OutputExpander.csproj
+++ b/Interface/Harp.OutputExpander/Harp.OutputExpander.csproj
@@ -17,7 +17,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0-build230803</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
This PR adds high-level operators to facilitate configuration of complex registers. The goal is to make it less error-prone to configure features with cross-register parameter interdependencies, such as the PWM feature or magnetic encoder. This is a test pattern which might be adopted in the future to other devices.

Fixes #5 
Fixes #6 
