### PR TITLE
Fix bit field values signalling input change

### DIFF
--- a/device.yml
+++ b/device.yml
@@ -346,8 +346,8 @@ bitMasks:
     bits:
       Aux0: 0x1
       Aux1: 0x2
-      Aux0Changed: 0x20
-      Aux1Changed: 0x40
+      Aux0Changed: 0x10
+      Aux1Changed: 0x20
     description: Specifies the state of auxiliary input lines.
   DigitalOutputs:
     description: Specifies the available digital output lines.


### PR DESCRIPTION
The bit fields for changing auxiliary input pins were shifted by 1 bit. The highest 4-bits in the word are the change bits and the lowest 4-bits the state.

Fixes #12 